### PR TITLE
Add support for analyzing the pull request label life cycle

### DIFF
--- a/dcos-dev-prod-analysis.py
+++ b/dcos-dev-prod-analysis.py
@@ -1097,14 +1097,16 @@ def analyze_merged_prs(prs, report):
             pr in filtered_prs],
         }
 
-    for metric in (
-            'time_pr_open_to_last_shipit',
-            'time_pr_open_to_last_rfr',
-            'time_last_shipit_to_pr_merge',
-            'time_last_rfr_to_pr_merge',
-            'time_last_rfr_to_last_shipit'
-            ):
-        df_dict[metric] = [
+    # All these metrics are time differences measured in seconds.
+    time_diff_metrics = (
+        'time_pr_open_to_last_shipit',
+        'time_pr_open_to_last_rfr',
+        'time_last_shipit_to_pr_merge',
+        'time_last_rfr_to_pr_merge',
+        'time_last_rfr_to_last_shipit'
+    )
+    for metric in time_diff_metrics:
+        df_dict[metric + '_seconds'] = [
             pr._label_transition_timings[metric].total_seconds()
             if pr._label_transition_timings[metric] is not None else np.NaN for
             pr in filtered_prs]
@@ -1116,6 +1118,15 @@ def analyze_merged_prs(prs, report):
         df_dict,
         index=[pd.Timestamp(pr.merged_at) for pr in filtered_prs]
         )
+    # Sort by time.
+    df.sort_index(inplace=True)
+
+    # Convert a number of time differences measured in seconds to days, for
+    # easier human consumption in plots.
+    df['opendays'] = df['openseconds'] / 86400
+
+    for metric in time_diff_metrics:
+        df[metric + '_days'] = df[metric + '_seconds'] / 86400
 
     log.info('Main Dataframe:')
     print(df)

--- a/dcos-dev-prod-analysis.py
+++ b/dcos-dev-prod-analysis.py
@@ -1307,8 +1307,8 @@ def plot_throughput(filtered_prs):
     return throughput, savefig('Pull request integration throughput')
 
 
-def _plot_latency_core(df):
-    ax = df['opendays'].plot(
+def _plot_latency_core(df, metricname):
+    ax = df[metricname].plot(
         # linestyle='dashdot',
         linestyle='None',
         color='gray',
@@ -1324,7 +1324,7 @@ def _plot_latency_core(df):
     #set_subtitle('Raw data')
     #plt.tight_layout(rect=(0, 0, 1, 0.95))
 
-    rollingwindow = df['opendays'].rolling('14d')
+    rollingwindow = df[metricname].rolling('14d')
     mean = rollingwindow.mean()
     median = rollingwindow.median()
 
@@ -1353,24 +1353,29 @@ def _plot_latency_core(df):
     return median, ax
 
 
-def plot_latency(df):
-    median, ax = _plot_latency_core(df)
+def plot_latency(df, metricname):
+
+    median, ax = _plot_latency_core(df, metricname)
     plt.tight_layout()
     figure_filepath_latency_raw_linscale = savefig(
-        'Pull request integration latency (linear scale)')
+        f'PR integration latency (linear scale), metric: {metricname}')
 
-    median, ax = _plot_latency_core(df)
+    median, ax = _plot_latency_core(df,  metricname)
     ax.set_yscale('log')
     plt.tight_layout()
     figure_filepath_latency_raw_logscale = savefig(
-        'Pull request integration latency (logarithmic scale)')
+        f'PR integration latency (logarithmic scale), metric:  {metricname}')
 
-    return median, figure_filepath_latency_raw_linscale, figure_filepath_latency_raw_logscale
+    return (
+        median,
+        figure_filepath_latency_raw_linscale,
+        figure_filepath_latency_raw_logscale
+    )
 
 
-def plot_latency_focus_on_mean(df):
+def plot_latency_focus_on_mean(df, metricname):
 
-    rollingwindow = df['opendays'].rolling('14d')
+    rollingwindow = df[metricname].rolling('14d')
     mean = rollingwindow.mean()
     ax = mean.plot(
         linestyle='solid',
@@ -1414,7 +1419,7 @@ def plot_latency_focus_on_mean(df):
     )
 
     plt.tight_layout()
-    return savefig('Pull request integration latency focus on mean')
+    return savefig(f'PR integration latency focus on mean, metric: {metricname}')
 
 
 def set_title(text):

--- a/dcos-dev-prod-analysis.py
+++ b/dcos-dev-prod-analysis.py
@@ -1075,15 +1075,19 @@ def analyze_merged_prs(prs, report):
     filtered_prs = [pr for pr in filtered_prs if 'train' not in pr.title.lower()]
     log.info('Number of filtered pull requests: %s', len(filtered_prs))
 
-    # Major goal is to look at train
-    # PRs separately, and to filter PRs by certain criteria in general, such as
+    # Future goal is to distinguish PR types, to look at train PRs separately,
+    # and to filter PRs by certain criteria in general, such as
     # - how many lines do they change
     # - are these just simple package bumps?
     # - ...
 
-    # This line assumes that somewhere in the code path a figure has been
-    # created before, now create a fresh one.
-    plt.figure()
+    log.info('Analyze label transitions in filtered PRs')
+    label_transitions = [pr_analyze_label_transitions(pr) for pr in filtered_prs]
+
+    log.info('Pull request label transition histogram, top 50')
+    counter = Counter(label_transitions)
+    for transition, count in counter.most_common(50):
+        print('{:>8}: {}'.format(count, transition))
 
     log.info('Build main Dataframe')
 

--- a/dcos-dev-prod-analysis.py
+++ b/dcos-dev-prod-analysis.py
@@ -702,7 +702,7 @@ def calc_override_comment_rate(
     df_raw = pd.DataFrame(
         {'commentcount': [1 for c in override_comments]},
         index=[
-            pd.Timestamp(c['comment_obj'].created_at, tz='UTC') for \
+            pd.Timestamp(c['comment_obj'].created_at, tz='UTC') for
                 c in override_comments
         ]
     )
@@ -852,7 +852,7 @@ def plot_override_comment_rate_two_windows(override_comments):
         marker='None',
         color='black',
         ax=ax
-        )
+    )
 
     # The legend story is shitty with pandas intertwined w/ mpl.
     # http://stackoverflow.com/a/30666612/145400
@@ -1064,7 +1064,7 @@ def analyze_merged_prs(prs, report):
 
     # Proceed with analyzing only those pull requests that were not created by
     # mergebot. This ignores an important class of pull request: all downstream
-    # PRs created via the bump-ee command. This is an intentional, following the
+    # PRs created via the bump-ee command. This is intentional, following the
     # idea that a pull request pair comprised of an upstream PR with the
     # corresponding downstream PR is tracking one unit of change to DC/OS.
     log.info('Filter pull requests not created by mergebot.')
@@ -1119,8 +1119,13 @@ def analyze_merged_prs(prs, report):
 
     log.info('Main Dataframe:')
     print(df)
+
     # Sort by time.
     df.sort_index(inplace=True)
+
+    # This line assumes that somewhere in the code path a figure has been
+    # created before, now create a fresh one.
+    plt.figure()
 
     df['opendays'] = df['openseconds'] / 86400
 

--- a/dcos-dev-prod-fetchdata.py
+++ b/dcos-dev-prod-fetchdata.py
@@ -56,9 +56,10 @@ def main():
 
     repo = GHUB.get_organization(org).get_repo(reponame)
     log.info('Working with repository `%s`', repo)
-    log_remaining_requests()
+
+    log.info('Request quota limit: %s', GHUB.get_rate_limit())
+    # check_request_quota_and_wait()
     fetch_prs_with_comments_for_repo(repo, reponame)
-    log_remaining_requests()
 
 
 def fetch_prs_with_comments_for_repo(repo, reponame):
@@ -261,9 +262,27 @@ def fetch_pull_requests(repo, reponame):
     return prs
 
 
-def log_remaining_requests():
-    remaining_requests = GHUB.get_rate_limit().rate.remaining
-    log.info('GitHub rate limit remaining requests: %r', remaining_requests)
+# def check_request_quota_and_wait():
+#     """
+#     GitHub allows 5000 HTTP requests against its API within 1 hour for 1
+#     account. Check quota and proceed if it looks good. Wait for quota to refill
+#     if consumed (takes 1 hour at moast).
+
+#     GHUB.get_rate_limit().rate.remaining issues an HTTP request which does not
+#     count against the quote. It however consumes time.
+
+#     GHUB.rate_limiting[0] is a local lookup based on internal bookkeeping. Use
+#     that so that this function can be called frequently without adding
+#     significant run time.
+#     """
+#     while True:
+#         # remaining = GHUB.get_rate_limit().rate.remaining
+#         remaining = GHUB.rate_limiting[0]
+#         if remaining > 10:
+#             log.info('GitHub API req quota: %r, proceed', remaining)
+#             break
+#         log.info('GitHub API req quota: %r, wait', remaining)
+#         time.sleep(60)
 
 
 def load_file_if_exists(filepath):

--- a/dcos-dev-prod-fetchdata.py
+++ b/dcos-dev-prod-fetchdata.py
@@ -132,6 +132,17 @@ def fetch_details_for_all_prs(prs_current_without_details, reponame):
             if age.total_seconds() < 60 * 60 * 24 * max_age_days:
                 old_prs_to_analyze.append(pr)
 
+        # If a previous run failed for whichever reason (for example as of the
+        # GitHub request quota limit not being properly handled ) then the
+        # pickled data might have stored the PR objects, but with the _events
+        # and/or the _comments properties missing. For those PRs perform the
+        # complete update.
+        for _, pr in prs_old_with_comments.items():
+            if not hasattr(pr, '_events') or not hasattr(pr, '_comments'):
+                # Adding the same PR twice should not be a problem, is
+                # uniqueified below.
+                old_prs_to_analyze.append(pr)
+
         log.info('Most recent PRs: %s', old_prs_to_analyze)
 
         log.info(

--- a/dcos-dev-prod-fetchdata.py
+++ b/dcos-dev-prod-fetchdata.py
@@ -135,35 +135,35 @@ def fetch_details_for_all_prs(prs_current_without_details, reponame):
         log.info('Most recent PRs: %s', old_prs_to_analyze)
 
         log.info(
-            'Fetching comments for %s recent PRs',
+            'Fetching comments & events for %s recent PRs',
             len(old_prs_to_analyze)
         )
 
         for pr in old_prs_to_analyze:
-            prs_to_fetch_comments_for[pr.number] = pr
+            prs_to_fetch_details_for[pr.number] = pr
 
-        if not prs_to_fetch_comments_for:
+        if not prs_to_fetch_details_for:
             log.info('Nothing to fetch, data on disk is up-to-date')
             return prs_old_with_comments
 
     else:
-        prs_to_fetch_comments_for = prs_current_without_comments
+        prs_to_fetch_details_for = prs_current_without_details
         # Fetch comments for all pull requests.
 
         log.info(
-            'Fetching comments for %s PRs',
-            len(prs_to_fetch_comments_for)
+            'Fetching comments & events for %s PRs',
+            len(prs_to_fetch_details_for)
         )
 
-    fetch_pr_comments_in_threadpool(prs_to_fetch_comments_for)
+    fetch_pr_details_in_threadpool(prs_to_fetch_details_for)
 
     if prs_old_with_comments is not None:
         # Combine data loaded from disk, and fresh data from GitHub.
-        prs_old_with_comments.update(prs_to_fetch_comments_for)
+        prs_old_with_comments.update(prs_to_fetch_details_for)
         prs_with_comments = prs_old_with_comments
     else:
-        # There was no old data; `prs_to_fetch_comments_for` is sufficient.
-        prs_with_comments = prs_to_fetch_comments_for
+        # There was no old data; `prs_to_fetch_details_for` is sufficient.
+        prs_with_comments = prs_to_fetch_details_for
 
     persist_data(prs_with_comments, filepath)
     # log.info('fetch_comments_for_all_prs(): return %s', prs_with_comments)

--- a/dcos-dev-prod-fetchdata.py
+++ b/dcos-dev-prod-fetchdata.py
@@ -66,47 +66,47 @@ def main():
 
 def fetch_prs_with_comments_for_repo(repo, reponame):
     prs = fetch_pull_requests(repo, reponame)
-    prs = fetch_comments_for_all_prs(prs, reponame)
+    prs = fetch_details_for_all_prs(prs, reponame)
     return prs
 
 
-def fetch_comments_for_all_prs(prs_current_without_comments, reponame):
+def fetch_details_for_all_prs(prs_current_without_details, reponame):
     # Expect `prs` to be a dictionary with the values being PullRequest objects.
 
-    log.info('Collect issue comments for each PR individually.')
+    log.info('Collect issue comments & events for each PR individually.')
 
     # name_prefix =
     # today = datetime.now().strftime('%Y-%m-%d')
     # filepath = today + '-' + name_prefix + '.pickle'
-    filepath = reponame + '_pull-requests-with-comments.pickle'
+    filepath = reponame + '_pull-requests-with-comments-events.pickle'
 
     prs_old_with_comments = load_file_if_exists(filepath)
 
     if prs_old_with_comments is not None:
 
-        # Fetch comments only for new pull requests.
-        # `prs_current_without_comments` might be fresher (contain more/newer
-        # PRs). `prs_current_without_comments` is a dictionary with the keys
+        # Fetch comments & events only for new pull requests.
+        # `prs_current_without_details` might be fresher (contain more/newer
+        # PRs). `prs_current_without_details` is a dictionary with the keys
         # being the PR numbers.
 
         log.info(
-            'Loaded %s PRs with comments from disk',
+            'Loaded %s PRs with comments & events from disk',
             len(prs_old_with_comments)
         )
 
-        prs_to_fetch_comments_for = {}
+        prs_to_fetch_details_for = {}
 
         # See which PRs are new, compared to what was persisted to disk.
-        new_pr_numbers = set(prs_current_without_comments.keys()) - \
+        new_pr_numbers = set(prs_current_without_details.keys()) - \
             set(prs_old_with_comments.keys())
 
         # For the newly seen PRs we definitely need to fetch comments.
         for n in new_pr_numbers:
-            prs_to_fetch_comments_for[n] = prs_current_without_comments[n]
+            prs_to_fetch_details_for[n] = prs_current_without_details[n]
 
         log.info(
             'Fetching comments for %s new PRs',
-            len(prs_to_fetch_comments_for)
+            len(prs_to_fetch_details_for)
         )
 
         # Note(JP): for the more recent pull requests it is likely that there


### PR DESCRIPTION
## Fetcher

Fetch pull request events.

GitHub's HTTP API for yielding all repository events should (as of documentation) yield all pull request events, listing 100 events per page so that just a small amount of HTTP requests should be required for fetching all relevant data.

But this does not seem to be true in practice. Therefore, fetch events explicitly for every single pull request. Because there are thousands of pull requests this requires sending thousands of additional HTTP requests for fetching all data. This on the other hand means that fetching all relevant data requires more than 5000 pull requests.

Therefore, this PR consolidates the fetcher to deal with two kinds of GitHub rate limiting and quota violations.

The data is stored in pickle files, as before.

## Analyzer

Add support for pull request label life cycle analysis. Extract various timing metrics for pull requests, if applicable:

        - time from opening PR to last ship it label
        - time from opening PR to last ready for review label
        - time from last ship it label to merge
        - time from last ready for review label to merge
        - time from last ready for review label to last ship it label

Add plots for metric 'time from last ship it label to merge' to HTML report.
